### PR TITLE
fixing the link for the j-tock auth to align with heroku

### DIFF
--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -1,7 +1,14 @@
 import JtockAuth from "j-tockauth";
 
+let apiUrl;
+if (process.env.NODE_ENV === "production") {
+  apiUrl = "https://news-on-rails-api.herokuapp.com";
+} else {
+  apiUrl = "http://localhost:3000";
+}
+
 const auth = new JtockAuth({
-  host: "http://localhost:3000",
+  host: apiUrl,
   prefixUrl: "/api/v1"
 });
 


### PR DESCRIPTION

## Changes proposed in this pull request:
* changing url to heruku